### PR TITLE
[Bugfix]: Throw error when appName is not provided since it's required for express-session

### DIFF
--- a/lib/sexpress.js
+++ b/lib/sexpress.js
@@ -481,6 +481,11 @@ class Sexpress {
 
 	init() {
 		// log(this.config.initSeqMessage)
+		if (!this.config.appName) {
+			throw new Error(
+				"Unable to configure express-session because 'appName' was not provided in config."
+			)
+		}
 
 		this.app.use(
 			session({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "sexpress",
-	"version": "0.0.24",
+	"version": "0.0.29",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sexpress",
-	"version": "0.0.28",
+	"version": "0.0.29",
 	"description": "A sexy wrapper around express for multitenant websites",
 	"main": "index.js",
 	"directories": {


### PR DESCRIPTION
Here's that change for a better error message on the appName! Sorry if it's another small one that might not have been worth reviewing.

After reading through the purpose of the secret value [here](https://github.com/expressjs/session#secret), it seemed right to me to error out rather than randomly generating the secret. A warning also didn't seem ideal since it does break the server even though it looks like the server started successfully.